### PR TITLE
Added Binary Uuid generator

### DIFF
--- a/src/Broadway/UuidGenerator/Rfc4122/Version4BinaryGenerator.php
+++ b/src/Broadway/UuidGenerator/Rfc4122/Version4BinaryGenerator.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the broadway/uuid-generator package.
+ *
+ * (c) Qandidate.com <opensource@qandidate.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Broadway\UuidGenerator\Rfc4122;
+
+use Broadway\UuidGenerator\UuidGeneratorInterface;
+use Rhumsaa\Uuid\Uuid;
+
+/**
+ * Generates a binary version4 uuid as defined in RFC 4122.
+ */
+class Version4BinaryGenerator implements UuidGeneratorInterface
+{
+    /**
+     * @return string
+     */
+    public function generate()
+    {
+        return Uuid::uuid4()->getBytes();
+    }
+}

--- a/test/Broadway/UuidGenerator/Rfc4122/Version4BinaryGeneratorTest.php
+++ b/test/Broadway/UuidGenerator/Rfc4122/Version4BinaryGeneratorTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the broadway/uuid-generator package.
+ *
+ * (c) Qandidate.com <opensource@qandidate.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Broadway\UuidGenerator\Rfc4122;
+
+use Broadway\UuidGenerator\TestCase;
+use Rhumsaa\Uuid\Uuid;
+
+class Version4BinaryGeneratorTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_should_generate_a_string()
+    {
+        $generator = new Version4BinaryGenerator();
+        $uuid = $generator->generate();
+
+        $this->assertInternalType('string', $uuid);
+        $this->assertEquals(16, strlen($uuid));
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_generate_a_version_4_uuid()
+    {
+        $generator = new Version4BinaryGenerator();
+        $uuid = $generator->generate();
+
+        $uuidObject = Uuid::fromBytes($uuid);
+
+        $this->assertEquals(4 , $uuidObject->getVersion());
+    }
+}
+


### PR DESCRIPTION
Your mysql storage will thank you for that. If you already have fragmented indexes, then at least make them only taking half the storage by using a binary type.

This is a predicate PR to enable an optimized DBAL event store here https://github.com/qandidate-labs/broadway
