### PR TITLE
Do not suggest but require rhumsaa/uuid

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,11 +4,8 @@
     "license": "MIT",
     "minimum-stability": "dev",
     "prefer-stable": true,
-    "require-dev": {
+    "require": {
         "rhumsaa/uuid": "~2.4"
-    },
-    "suggest": {
-        "rhumsaa/uuid": "Allows creating UUIDs"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
As the version 4 generator [highly depends on rhumsaa/uuid](https://github.com/qandidate-labs/broadway-uuid-generator/blob/master/src/Broadway/UuidGenerator/Rfc4122/Version4Generator.php#L15), wouldn't it be better to require `rhumsaa/uuid` instead of suggesting it? You won't be able to use the v4 generator if you don't anyway…
