### PR TITLE
allow to use ramsey/uuid ^3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: php
 
 php:
-  - 5.3
-  - 5.4
   - 5.5
   - 5.6
+  - 7
   - hhvm
 
 install:

--- a/composer.json
+++ b/composer.json
@@ -5,19 +5,19 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require-dev": {
-        "rhumsaa/uuid": "~2.4"
+        "ramsey/uuid": "^2.4||^3.0"
     },
     "suggest": {
-        "rhumsaa/uuid": "Allows creating UUIDs"
+        "ramsey/uuid": "Allows creating UUIDs"
     },
     "autoload": {
-        "psr-0": {
-            "Broadway\\UuidGenerator\\": "src/"
+        "psr-4": {
+            "Broadway\\UuidGenerator\\": "src/Broadway/UuidGenerator"
         }
     },
     "autoload-dev": {
-        "psr-0": {
-            "Broadway\\UuidGenerator\\": "test/"
+        "psr-4": {
+            "Broadway\\UuidGenerator\\": "test/Broadway/UuidGenerator"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,9 @@
     "license": "MIT",
     "minimum-stability": "dev",
     "prefer-stable": true,
+    "require": {
+        "php": ">=5.5.9"
+    },
     "require-dev": {
         "ramsey/uuid": "^2.4||^3.0"
     },

--- a/src/Broadway/UuidGenerator/Rfc4122/Version4Generator.php
+++ b/src/Broadway/UuidGenerator/Rfc4122/Version4Generator.php
@@ -12,18 +12,39 @@
 namespace Broadway\UuidGenerator\Rfc4122;
 
 use Broadway\UuidGenerator\UuidGeneratorInterface;
-use Rhumsaa\Uuid\Uuid;
+use LogicException;
 
 /**
  * Generates a version4 uuid as defined in RFC 4122.
  */
 class Version4Generator implements UuidGeneratorInterface
 {
+    private $className;
+
+    public function __construct()
+    {
+        $this->className = $this->getClassName();
+    }
+
     /**
      * @return string
      */
     public function generate()
     {
-        return Uuid::uuid4()->toString();
+        return call_user_func([$this->className, 'uuid4'])
+            ->toString();
+    }
+
+    private function getClassName()
+    {
+        if (class_exists('Ramsey\Uuid\Uuid')) {
+            return '\Ramsey\Uuid\Uuid';
+        }
+
+        if (class_exists('Rhumsaa\Uuid\Uuid')) {
+            return '\Rhumsaa\Uuid\Uuid';
+        }
+
+        throw new LogicException('Version4Generator requires library ramsey/uuid.');
     }
 }

--- a/test/Broadway/UuidGenerator/Rfc4122/Version4GeneratorTest.php
+++ b/test/Broadway/UuidGenerator/Rfc4122/Version4GeneratorTest.php
@@ -12,10 +12,16 @@
 namespace Broadway\UuidGenerator\Rfc4122;
 
 use Broadway\UuidGenerator\TestCase;
-use Rhumsaa\Uuid\Uuid;
 
 class Version4GeneratorTest extends TestCase
 {
+    private $className;
+
+    public function __construct()
+    {
+        $this->className = $this->getClassName();
+    }
+
     /**
      * @test
      */
@@ -35,9 +41,22 @@ class Version4GeneratorTest extends TestCase
         $generator = new Version4Generator();
         $uuid = $generator->generate();
 
-        $uuidObject = Uuid::fromString($uuid);
+        $uuidObject = call_user_func([$this->className, 'fromString'], $uuid);
 
         $this->assertEquals(4 , $uuidObject->getVersion());
+    }
+
+    private function getClassName()
+    {
+        if (class_exists('Ramsey\Uuid\Uuid')) {
+            return '\Ramsey\Uuid\Uuid';
+        }
+
+        if (class_exists('Rhumsaa\Uuid\Uuid')) {
+            return '\Rhumsaa\Uuid\Uuid';
+        }
+
+        throw new LogicException('Version4Generator requires library ramsey/uuid.');
     }
 }
 


### PR DESCRIPTION
elaborated on https://github.com/qandidate-labs/broadway-uuid-generator/pull/3

here the class_exist is only called during object instantiation.
